### PR TITLE
Add Jira OAuth 2.0 (3LO) token manager

### DIFF
--- a/src/Jira/TokenManager.ts
+++ b/src/Jira/TokenManager.ts
@@ -1,0 +1,255 @@
+import {
+  DateTime,
+  Deferred,
+  Effect,
+  Encoding,
+  Layer,
+  Option,
+  Schedule,
+  Schema,
+  Semaphore,
+  ServiceMap,
+} from "effect"
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientError,
+  HttpClientRequest,
+  HttpClientResponse,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http"
+import { NodeHttpServer } from "@effect/platform-node"
+import { createServer } from "node:http"
+import { KeyValueStore } from "effect/unstable/persistence"
+import { Prompt } from "effect/unstable/cli"
+import { layerKvs } from "../Kvs.ts"
+
+export class ClientCredentials extends Schema.Class<ClientCredentials>(
+  "lalph/Jira/ClientCredentials",
+)({
+  clientId: Schema.String,
+  clientSecret: Schema.String,
+}) {}
+
+export class TokenManager extends ServiceMap.Service<TokenManager>()(
+  "lalph/Jira/TokenManager",
+  {
+    make: Effect.gen(function* () {
+      const kvs = KeyValueStore.prefix(
+        yield* KeyValueStore.KeyValueStore,
+        "jira.accessToken",
+      )
+      const tokenStore = KeyValueStore.toSchemaStore(kvs, AccessToken)
+
+      const credentialsKvs = KeyValueStore.prefix(
+        yield* KeyValueStore.KeyValueStore,
+        "jira.clientCredentials",
+      )
+      const credentialsStore = KeyValueStore.toSchemaStore(
+        credentialsKvs,
+        ClientCredentials,
+      )
+
+      const httpClient = (yield* HttpClient.HttpClient).pipe(
+        HttpClient.filterStatusOk,
+        HttpClient.retryTransient({
+          schedule: Schedule.spaced(1000),
+        }),
+      )
+
+      // Resolve credentials eagerly during service construction
+      const existingCreds = yield* Effect.orDie(credentialsStore.get(""))
+      const creds: ClientCredentials = yield* Option.match(existingCreds, {
+        onSome: Effect.succeed,
+        onNone: () =>
+          Effect.gen(function* () {
+            const clientId = yield* Prompt.text({
+              message:
+                "Enter your Jira OAuth app Client ID (from developer.atlassian.com):",
+            })
+            const clientSecret = yield* Prompt.text({
+              message: "Enter your Jira OAuth app Client Secret:",
+            })
+            const newCreds = new ClientCredentials({ clientId, clientSecret })
+            yield* Effect.orDie(credentialsStore.set("", newCreds))
+            return newCreds
+          }),
+      })
+
+      let currentToken = yield* Effect.orDie(tokenStore.get(""))
+      const set = (token: Option.Option<AccessToken>) =>
+        Option.match(token, {
+          onNone: () =>
+            Effect.orDie(tokenStore.remove("")).pipe(
+              Effect.map(() => {
+                currentToken = Option.none()
+              }),
+            ),
+          onSome: (token) =>
+            Effect.orDie(tokenStore.set("", token)).pipe(
+              Effect.map(() => {
+                currentToken = Option.some(token)
+              }),
+            ),
+        })
+
+      const getNoLock: Effect.Effect<
+        AccessToken,
+        HttpClientError.HttpClientError | Schema.SchemaError
+      > = Effect.uninterruptibleMask(
+        Effect.fnUntraced(function* (restore) {
+          if (Option.isNone(currentToken)) {
+            const newToken = yield* restore(pkce)
+            yield* set(Option.some(newToken))
+            return newToken
+          } else if (currentToken.value.isExpired()) {
+            const newToken = yield* refresh(currentToken.value)
+            yield* set(newToken)
+            if (Option.isNone(newToken)) {
+              return yield* getNoLock
+            }
+            return newToken.value
+          }
+          return currentToken.value
+        }),
+      )
+      const get = Semaphore.makeUnsafe(1).withPermit(getNoLock)
+
+      const pkce = Effect.gen(function* () {
+        const deferred = yield* Deferred.make<typeof CallbackParams.Type>()
+
+        const CallbackRoute = HttpRouter.add(
+          "GET",
+          "/callback",
+          Effect.gen(function* () {
+            const params = yield* callbackParams
+            yield* Deferred.succeed(deferred, params)
+            return yield* HttpServerResponse.html`
+<html>
+  <body style="font-family: sans-serif; text-align: center; margin-top: 50px;">
+    <h1>Lalph login Successful</h1>
+    <p>You can close this window now.</p>
+  </body>
+</html>
+`
+          }),
+        )
+        yield* HttpRouter.serve(CallbackRoute, {
+          disableListenLog: true,
+          disableLogger: true,
+        }).pipe(
+          Layer.provide(
+            NodeHttpServer.layer(createServer, {
+              port: 34339,
+              disablePreemptiveShutdown: true,
+            }),
+          ),
+          Layer.build,
+          Effect.orDie,
+        )
+        const redirectUri = `http://localhost:34339/callback`
+
+        const verifier = crypto.randomUUID()
+        const verifierSha256 = yield* Effect.promise(() =>
+          crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier)),
+        )
+        const challenge = Encoding.encodeBase64Url(
+          new Uint8Array(verifierSha256),
+        )
+
+        const scopes = [
+          "read:jira-work",
+          "read:jira-user",
+          "write:jira-work",
+          "offline_access",
+        ].join(" ")
+
+        const url = `https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=${creds.clientId}&scope=${encodeURIComponent(scopes)}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&prompt=consent&code_challenge=${challenge}&code_challenge_method=S256`
+
+        console.log("Open this URL to login to Jira:", url)
+
+        const params = yield* Deferred.await(deferred)
+
+        const res = yield* HttpClientRequest.post(
+          "https://auth.atlassian.com/oauth/token",
+        ).pipe(
+          HttpClientRequest.bodyUrlParams({
+            code: params.code,
+            redirect_uri: redirectUri,
+            client_id: creds.clientId,
+            client_secret: creds.clientSecret,
+            code_verifier: verifier,
+            grant_type: "authorization_code",
+          }),
+          httpClient.execute,
+          Effect.flatMap(HttpClientResponse.schemaBodyJson(TokenResponse)),
+        )
+
+        return AccessToken.fromResponse(res)
+      }).pipe(Effect.scoped)
+
+      const refresh = Effect.fnUntraced(function* (token: AccessToken) {
+        const res = yield* HttpClientRequest.post(
+          "https://auth.atlassian.com/oauth/token",
+        ).pipe(
+          HttpClientRequest.bodyUrlParams({
+            refresh_token: token.refreshToken,
+            client_id: creds.clientId,
+            client_secret: creds.clientSecret,
+            grant_type: "refresh_token",
+          }),
+          httpClient.execute,
+          Effect.flatMap(HttpClientResponse.schemaBodyJson(TokenResponse)),
+        )
+        return AccessToken.fromResponse(res)
+      }, Effect.option)
+
+      return { get } as const
+    }),
+  },
+) {
+  static layer = Layer.effect(this, this.make).pipe(
+    Layer.provide([layerKvs, FetchHttpClient.layer]),
+  )
+}
+
+export class AccessToken extends Schema.Class<AccessToken>(
+  "lalph/Jira/AccessToken",
+)({
+  token: Schema.String,
+  expiresAt: Schema.DateTimeUtc,
+  refreshToken: Schema.String,
+}) {
+  static fromResponse(res: typeof TokenResponse.Type): AccessToken {
+    return new AccessToken({
+      token: res.access_token,
+      refreshToken: res.refresh_token,
+      expiresAt: DateTime.nowUnsafe().pipe(
+        DateTime.add({ seconds: res.expires_in }),
+      ),
+    })
+  }
+
+  readonly expiresAtEarly = this.expiresAt.pipe(
+    DateTime.subtract({ minutes: 30 }),
+  )
+
+  isExpired(): boolean {
+    return DateTime.isPastUnsafe(this.expiresAtEarly)
+  }
+}
+
+const CallbackParams = Schema.Struct({
+  code: Schema.String,
+})
+const callbackParams = HttpServerRequest.schemaSearchParams(CallbackParams)
+
+const TokenResponse = Schema.Struct({
+  access_token: Schema.String,
+  token_type: Schema.String,
+  expires_in: Schema.Number,
+  refresh_token: Schema.String,
+  scope: Schema.String,
+})


### PR DESCRIPTION
Closes #3

## Summary
- Adds `src/Jira/TokenManager.ts` implementing OAuth 2.0 (3LO) token management for Jira Cloud authentication
- Follows the same pattern as `Linear/TokenManager.ts` with PKCE flow, token refresh, and semaphore-protected access
- Client credentials (clientId, clientSecret) are prompted once and stored in KVS under `"jira.clientCredentials"`
- Access tokens are persisted in KVS under `"jira.accessToken"` with 30-minute early expiration buffer
- PKCE OAuth flow runs on local HTTP server port 34339 with `/callback` route
- Token refresh uses Atlassian's OAuth token endpoint with `grant_type=refresh_token`

## Test plan
- [x] `pnpm check` passes (typecheck, lint, build)
- [ ] Manual test: run Jira OAuth flow end-to-end with a real Jira Cloud app