### PR TITLE
Add changeset for Jira issue source feature

### DIFF
--- a/.changeset/add-jira-issue-source.md
+++ b/.changeset/add-jira-issue-source.md
@@ -1,0 +1,5 @@
+---
+"lalph": minor
+---
+
+add Jira Cloud issue source integration


### PR DESCRIPTION
Closes #7

## Summary
- Adds a changeset file (`.changeset/add-jira-issue-source.md`) describing the new Jira Cloud issue source integration as a minor version bump.
- Rebased onto latest master per review feedback.