### PR TITLE
Register Jira in CurrentIssueSource

### DIFF
--- a/src/CurrentIssueSource.ts
+++ b/src/CurrentIssueSource.ts
@@ -11,6 +11,7 @@ import {
   SubscriptionRef,
 } from "effect"
 import { allProjects, CurrentProjectId, Setting, Settings } from "./Settings.ts"
+import { JiraIssueSource } from "./Jira.ts"
 import { LinearIssueSource } from "./Linear.ts"
 import { Prompt } from "effect/unstable/cli"
 import { GithubIssueSource } from "./Github.ts"
@@ -32,6 +33,12 @@ const issueSources: ReadonlyArray<typeof CurrentIssueSource.Service> = [
     name: "GitHub Issues",
     layer: GithubIssueSource,
     githubPrInstructions: `At the start of your PR description, include a line that closes the issue: Closes {task id}`,
+  },
+  {
+    id: "jira",
+    name: "Jira",
+    layer: JiraIssueSource,
+    githubPrInstructions: `Include the Jira issue key (e.g. PROJ-123) in the PR title or description so it links back to the Jira issue.`,
   },
 ]
 
@@ -67,8 +74,16 @@ export class CurrentIssueSource extends ServiceMap.Service<
     readonly name: string
     readonly layer: Layer.Layer<
       IssueSource,
-      Layer.Error<typeof LinearIssueSource | typeof GithubIssueSource>,
-      Layer.Services<typeof LinearIssueSource | typeof GithubIssueSource>
+      Layer.Error<
+        | typeof LinearIssueSource
+        | typeof GithubIssueSource
+        | typeof JiraIssueSource
+      >,
+      Layer.Services<
+        | typeof LinearIssueSource
+        | typeof GithubIssueSource
+        | typeof JiraIssueSource
+      >
     >
     readonly githubPrInstructions: string
   }

--- a/src/CurrentIssueSource.ts
+++ b/src/CurrentIssueSource.ts
@@ -38,7 +38,7 @@ const issueSources: ReadonlyArray<typeof CurrentIssueSource.Service> = [
     id: "jira",
     name: "Jira",
     layer: JiraIssueSource,
-    githubPrInstructions: `Include the Jira issue key (e.g. PROJ-123) in the PR title or description so it links back to the Jira issue.`,
+    githubPrInstructions: `The PR title should include the Jira issue key (e.g. PROJ-123). Include the issue key in the PR description as well.`,
   },
 ]
 


### PR DESCRIPTION
Closes #6

## Summary

- Imports `JiraIssueSource` from `./Jira.ts` and registers it as a selectable issue source in `CurrentIssueSource`
- Adds Jira entry to `issueSources` array with `id: "jira"`, `name: "Jira"`, `layer: JiraIssueSource`, and `githubPrInstructions` matching the spec
- Updates `Layer.Error` and `Layer.Services` union types to include `typeof JiraIssueSource`
- Rebased onto master now that Jira dependencies (PRs #8, #9, #10, #11) have been merged

## Test plan

- [x] `pnpm check` passes (typecheck, lint, build)