### PR TITLE
Add hard validation gate for chosen tasks

### DIFF
--- a/.changeset/hard-gate-blocked-tasks.md
+++ b/.changeset/hard-gate-blocked-tasks.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+add hard validation gate to reject blocked or non-todo tasks after selection

--- a/src/Agents/chooser.ts
+++ b/src/Agents/chooser.ts
@@ -47,6 +47,9 @@ export const agentChooser = Effect.fnUntraced(function* (options: {
     )
     const prdTask = yield* prd.findById(result.taskId)
     if (!prdTask) return yield* new ChosenTaskNotFound()
+    if (prdTask.state !== "todo" || prdTask.blockedBy.length > 0) {
+      return yield* new ChosenTaskNotFound()
+    }
     return {
       id: result.taskId,
       githubPrNumber: result.githubPrNumber ?? null,
@@ -86,8 +89,11 @@ export const agentChooser = Effect.fnUntraced(function* (options: {
     Effect.flatMap(
       Effect.fnUntraced(function* (task) {
         const prdTask = yield* prd.findById(task.id)
-        if (prdTask) return { ...task, prd: prdTask }
-        return yield* new ChosenTaskNotFound()
+        if (!prdTask) return yield* new ChosenTaskNotFound()
+        if (prdTask.state !== "todo" || prdTask.blockedBy.length > 0) {
+          return yield* new ChosenTaskNotFound()
+        }
+        return { ...task, prd: prdTask }
       }),
     ),
   )

--- a/src/TaskTools.ts
+++ b/src/TaskTools.ts
@@ -92,6 +92,8 @@ export class TaskChooseTools extends Toolkit.make(
       taskId: Schema.String,
       githubPrNumber: Schema.optional(Schema.Number),
     }),
+    success: Schema.optional(Schema.String),
+    dependencies: [CurrentProjectId],
   }),
   Tool.make("listEligibleTasks", {
     description:
@@ -130,9 +132,17 @@ export const TaskToolsHandlers = TaskToolsWithChoose.toLayer(
         yield* Effect.log(`Calling "chooseTask"`).pipe(
           Effect.annotateLogs(options),
         )
+        const projectId = yield* CurrentProjectId
+        const task = yield* source.findById(projectId, options.taskId)
+        if (!task || task.state !== "todo" || task.blockedBy.length > 0) {
+          yield* Effect.logWarning(
+            `Task ${options.taskId} is not eligible: ${!task ? "not found" : task.state !== "todo" ? `state is "${task.state}"` : "has blockers"}`,
+          )
+          return "Error: the chosen task is not eligible. It must be in 'todo' state with no blockers. Please choose a different task."
+        }
         const deferred = yield* ChosenTaskDeferred
         yield* Deferred.succeed(deferred, options)
-      }),
+      }, Effect.orDie),
       createTask: Effect.fn("TaskTools.createTask")(function* (options) {
         yield* Effect.log(`Calling "createTask"`)
         const projectId = yield* CurrentProjectId


### PR DESCRIPTION
Closes #13

## Summary

- **`src/TaskTools.ts` `chooseTask` handler**: Added `CurrentProjectId` to dependencies, looks up the task via `IssueSource.findById`, and verifies `state === "todo"` and `blockedBy.length === 0`. If the task is ineligible, logs a warning and returns an error string to the AI caller without resolving the deferred.
- **`src/Agents/chooser.ts`**: Added eligibility checks after `prd.findById` in both the Clanka path and the CLI agent path — rejects with `ChosenTaskNotFound` if the task's state is not "todo" or it has blockers.
- Added changeset for patch bump.

## Test plan
- [ ] Verify `pnpm check` passes (typecheck, lint, build)
- [ ] Test that choosing a blocked task returns an error to the AI caller
- [ ] Test that choosing a non-todo task returns an error to the AI caller
- [ ] Test that choosing an eligible task still works normally