### PR TITLE
Add interactive issue mode

### DIFF
--- a/.changeset/add-interactive-issue-mode.md
+++ b/.changeset/add-interactive-issue-mode.md
@@ -1,0 +1,5 @@
+---
+"lalph": minor
+---
+
+Add `lalph issue --interactive` to interview for issue details, review a generated draft, and then create the issue.

--- a/.specs/README.md
+++ b/.specs/README.md
@@ -3,4 +3,5 @@
 - `prd-service-polling-sync.md`: Adds PRD service polling to keep `prd.yml` synced with remote issue updates.
 - `cli-agent-presets.md`: Adds CLI agent presets with label-based matching and prompts.
 - `lalph-cli-help-readme-docs.md`: Refreshes CLI help text and README with concise feature usage.
+- `lalph-interactive-issue-mode.md`: Adds `lalph issue --interactive`, shared issue-draft helpers, agent interview support, and deterministic `.lalph/issue-draft.md` handling.
 - `lalph-ralph-mode-cleanup.md`: Refactors Ralph mode branching into named helpers across root and agents for readability.

--- a/.specs/lalph-interactive-issue-mode.md
+++ b/.specs/lalph-interactive-issue-mode.md
@@ -1,0 +1,43 @@
+# Interactive Issue Mode
+
+Add an interactive variant of `lalph issue` that interviews the user through a
+supported CLI agent, writes a deterministic draft to `.lalph/issue-draft.md`,
+requires editor review, and only then creates the issue in the active issue
+source.
+
+## Goals
+
+- Keep the existing `lalph issue` editor-first flow unchanged by default.
+- Share issue draft parsing, validation, recovery, and final submission logic
+  between the non-interactive and interactive paths.
+- Support terminal interviews only for CLI agents that can run with inherited
+  stdio and ask clarifying questions directly.
+
+## User Flow
+
+1. `lalph issue --interactive` resolves the active project and issue source.
+2. Lalph prompts for a high-level issue request and an agent preset.
+3. The selected agent interviews the user in the terminal and writes the final
+   draft to `.lalph/issue-draft.md`.
+4. Lalph opens that draft in the editor for final review.
+5. If the draft is malformed, the user can reopen the editor to repair it.
+6. After successful validation, lalph submits the issue through
+   `IssueSource.createIssue`.
+
+## Draft Lifecycle
+
+- Use `.lalph/issue-draft.md` as the only live draft path.
+- Fail fast if a concurrent interview lock exists.
+- If a stale draft exists without a lock, move it aside before starting a new
+  session.
+- Preserve the draft on interviewer failure, missing output, validation
+  failure, or editor cancellation.
+- Remove the live draft after a successful issue creation.
+
+## Agent Support
+
+- Add `CliAgent.commandIssue` for interactive interview launches.
+- Supported built-in agents: the ones with an explicit `commandIssue`
+  implementation.
+- Unsupported built-in agents must fail with a clear error before the interview
+  starts.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ npx -y lalph@latest
 - Inspect and configure agent presets: `lalph agents ls`
 - Start plan mode: `lalph plan`
 - Create an issue from your editor: `lalph issue`
+- Interview with an agent before creating an issue: `lalph issue --interactive`
 - Choose your issue source integration (applies to all projects): `lalph source`
 
 It is recommended to add `.lalph/` to your `.gitignore` to avoid committing your
@@ -94,6 +95,15 @@ lalph plan tasks .specs/my-spec.md
 `lalph issue` opens a new-issue template in your editor. When you save and close
 the file, the issue is created in the current issue source.
 
+`lalph issue --interactive` prompts for a high-level request and an agent
+preset, runs an interactive terminal interview, writes the generated draft to
+`.lalph/issue-draft.md`, and then opens that draft in your editor for required
+final review before creating the issue.
+
+Interactive issue interviews currently require a preset whose CLI agent supports
+interactive terminal sessions. Built-in support is implemented for `opencode`,
+`claude`, and `codex`; `clanka` and `amp` fail fast with an explicit error.
+
 Anything below the front matter is used as the issue description.
 
 Front matter fields:
@@ -107,6 +117,8 @@ Front matter fields:
 ```bash
 lalph issue
 lalph i
+lalph issue --interactive
+lalph i --interactive
 ```
 
 ## Development

--- a/src/Agents/issueInterviewer.ts
+++ b/src/Agents/issueInterviewer.ts
@@ -1,0 +1,68 @@
+import { Data, Effect, FileSystem, Path, pipe } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { PromptGen } from "../PromptGen.ts"
+import type { CliAgentPreset } from "../domain/CliAgentPreset.ts"
+
+export class UnsupportedIssueInterviewAgent extends Data.TaggedError(
+  "UnsupportedIssueInterviewAgent",
+)<{
+  readonly agentId: string
+}> {
+  readonly message = `Interactive issue interviews are not supported for the "${this.agentId}" CLI agent.`
+}
+
+export class IssueInterviewFailed extends Data.TaggedError(
+  "IssueInterviewFailed",
+)<{
+  readonly exitCode: number
+}> {
+  readonly message = `The interactive issue interviewer exited with code ${this.exitCode}.`
+}
+
+export const agentIssueInterviewer = Effect.fn("agentIssueInterviewer")(
+  function* (options: {
+    readonly cwd: string
+    readonly projectId: string
+    readonly issueSourceName: string
+    readonly request: string
+    readonly draftPath: string
+    readonly preset: CliAgentPreset
+  }) {
+    const fs = yield* FileSystem.FileSystem
+    const pathService = yield* Path.Path
+    const promptGen = yield* PromptGen
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+
+    const cliCommand = options.preset.cliAgent.commandIssue?.({
+      prompt: promptGen.promptIssueInterview({
+        projectId: options.projectId,
+        issueSourceName: options.issueSourceName,
+        request: options.request,
+        draftPath: pathService.relative(options.cwd, options.draftPath),
+      }),
+      prdFilePath: (yield* fs.exists(
+        pathService.join(options.cwd, ".lalph", "prd.yml"),
+      ))
+        ? pathService.join(".lalph", "prd.yml")
+        : undefined,
+      extraArgs: options.preset.extraArgs,
+    })
+
+    if (!cliCommand) {
+      return yield* new UnsupportedIssueInterviewAgent({
+        agentId: options.preset.cliAgent.id,
+      })
+    }
+
+    const exitCode = yield* pipe(
+      cliCommand,
+      ChildProcess.setCwd(options.cwd),
+      options.preset.withCommandPrefix,
+      spawner.exitCode,
+    )
+
+    if (exitCode !== 0) {
+      return yield* new IssueInterviewFailed({ exitCode })
+    }
+  },
+)

--- a/src/IssueDraft.ts
+++ b/src/IssueDraft.ts
@@ -17,6 +17,8 @@ autoMerge: false
 
 `
 
+export const issueTitlePlaceholder = "Issue Title"
+
 export const interactiveIssueDraftRelativePath = ".lalph/issue-draft.md"
 
 const FrontMatterSchema = Schema.toCodecJson(
@@ -185,7 +187,16 @@ export const reviewIssueDraft = Effect.fn("reviewIssueDraft")(
 
 export const reviewIssueDraftFileUntilValid = Effect.fn(
   "reviewIssueDraftFileUntilValid",
-)(function* (path: string) {
+)(function* (
+  path: string,
+  options?: {
+    readonly validate?: (parsed: {
+      readonly content: string
+      readonly frontMatter: typeof FrontMatterSchema.Type
+      readonly issue: PrdIssue
+    }) => string | undefined
+  },
+) {
   while (true) {
     const content = yield* reviewIssueDraft({ path })
     if (Option.isNone(content)) {
@@ -211,13 +222,17 @@ export const reviewIssueDraftFileUntilValid = Effect.fn(
       }),
     )
     if (Option.isSome(parsed)) {
-      return parsed
+      const validationMessage = options?.validate?.(parsed.value)
+      if (validationMessage === undefined) {
+        return parsed
+      }
+      yield* Effect.logError(validationMessage)
+    } else {
+      yield* Effect.logError(validationError!.message)
     }
-
-    yield* Effect.logError(validationError!.message)
     const reopen = yield* Prompt.toggle({
       message:
-        "The issue draft is malformed. Reopen it in your editor to repair it?",
+        "The issue draft is invalid. Reopen it in your editor to repair it?",
       initial: true,
     })
     if (!reopen) {

--- a/src/IssueDraft.ts
+++ b/src/IssueDraft.ts
@@ -1,0 +1,283 @@
+import { Data, Effect, Exit, FileSystem, Option, Path, Schema } from "effect"
+import * as Yaml from "yaml"
+import { Editor } from "./Editor.ts"
+import { IssueSource } from "./IssueSource.ts"
+import { PrdIssue } from "./domain/PrdIssue.ts"
+import type { ProjectId } from "./domain/Project.ts"
+import { resolveLalphDirectory } from "./shared/lalphDirectory.ts"
+import { Prompt } from "effect/unstable/cli"
+
+export const issueTemplate = `---
+title: Issue Title
+priority: 3
+estimate: null
+blockedBy: []
+autoMerge: false
+---
+
+`
+
+export const interactiveIssueDraftRelativePath = ".lalph/issue-draft.md"
+
+const FrontMatterSchema = Schema.toCodecJson(
+  Schema.Struct({
+    title: Schema.String,
+    priority: Schema.Finite,
+    estimate: Schema.NullOr(Schema.Finite),
+    blockedBy: Schema.Array(Schema.String),
+    autoMerge: Schema.Boolean,
+  }),
+)
+
+export class IssueDraftValidationError extends Data.TaggedError(
+  "IssueDraftValidationError",
+)<{
+  readonly message: string
+}> {}
+
+export class InteractiveIssueDraftInProgress extends Data.TaggedError(
+  "InteractiveIssueDraftInProgress",
+)<{
+  readonly draftPath: string
+}> {
+  readonly message = `An interactive issue draft is already in progress at ${this.draftPath}`
+}
+
+export class InteractiveIssueDraftMissing extends Data.TaggedError(
+  "InteractiveIssueDraftMissing",
+)<{
+  readonly draftPath: string
+}> {
+  readonly message = `The interviewer did not create a draft at ${this.draftPath}`
+}
+
+export const parseIssueDraft = Effect.fn("parseIssueDraft")(function* (
+  content: string,
+): Effect.fn.Return<
+  {
+    readonly content: string
+    readonly frontMatter: typeof FrontMatterSchema.Type
+    readonly issue: PrdIssue
+  },
+  IssueDraftValidationError
+> {
+  const trimmed = content.trim()
+  if (trimmed.length === 0) {
+    return yield* new IssueDraftValidationError({
+      message: "Issue draft is empty.",
+    })
+  }
+
+  const lines = trimmed.split("\n")
+  if (lines[0]?.trim() !== "---") {
+    return yield* new IssueDraftValidationError({
+      message:
+        "Issue draft must start with YAML front matter delimited by ---.",
+    })
+  }
+
+  const endIndex = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === "---",
+  )
+  if (endIndex === -1) {
+    return yield* new IssueDraftValidationError({
+      message: "Issue draft is missing the closing --- front matter delimiter.",
+    })
+  }
+
+  const yamlContent = lines.slice(1, endIndex).join("\n")
+  const description = lines
+    .slice(endIndex + 1)
+    .join("\n")
+    .trim()
+
+  const parsedYaml = yield* Effect.try({
+    try: () => Yaml.parse(yamlContent),
+    catch: (cause) =>
+      new IssueDraftValidationError({
+        message: `Failed to parse issue front matter: ${String(cause)}`,
+      }),
+  })
+
+  const frontMatter = yield* Schema.decodeEffect(FrontMatterSchema)(
+    parsedYaml,
+  ).pipe(
+    Effect.mapError(
+      (cause) =>
+        new IssueDraftValidationError({
+          message: `Invalid issue front matter: ${String(cause)}`,
+        }),
+    ),
+  )
+
+  return {
+    content: trimmed,
+    frontMatter,
+    issue: new PrdIssue({
+      id: null,
+      ...frontMatter,
+      description,
+      state: "todo",
+    }),
+  }
+})
+
+export const createIssueFromDraft = Effect.fn("createIssueFromDraft")(
+  function* (options: {
+    readonly projectId: ProjectId
+    readonly content: string
+  }) {
+    const source = yield* IssueSource
+    const parsed = yield* parseIssueDraft(options.content)
+    const created = yield* source.createIssue(options.projectId, parsed.issue)
+    return {
+      created,
+      parsed,
+    }
+  },
+)
+
+export const recoverIssueDraftOnFailure = Effect.fn(
+  "recoverIssueDraftOnFailure",
+)(function* (content: string) {
+  const editor = yield* Editor
+
+  yield* Effect.addFinalizer((exit) => {
+    if (Exit.isSuccess(exit) || content.trim().length === 0) {
+      return Effect.void
+    }
+
+    return editor.saveTemp(content, { suffix: ".md" }).pipe(
+      Effect.flatMap((file) => Effect.log(`Saved your issue to: ${file}`)),
+      Effect.ignore,
+    )
+  })
+})
+
+export const reviewIssueDraft = Effect.fn("reviewIssueDraft")(
+  function* (options: {
+    readonly initialContent?: string
+    readonly path?: string
+  }) {
+    const editor = yield* Editor
+    const fs = yield* FileSystem.FileSystem
+
+    if (options.path) {
+      const exitCode = yield* editor.edit(options.path)
+      if (exitCode !== 0) {
+        return Option.none<string>()
+      }
+
+      const content = (yield* fs.readFileString(options.path)).trim()
+      if (content.length === 0) {
+        return Option.none<string>()
+      }
+
+      return Option.some(content)
+    }
+
+    return yield* editor.editTemp({
+      suffix: ".md",
+      initialContent: options.initialContent ?? issueTemplate,
+    })
+  },
+)
+
+export const reviewIssueDraftFileUntilValid = Effect.fn(
+  "reviewIssueDraftFileUntilValid",
+)(function* (path: string) {
+  while (true) {
+    const content = yield* reviewIssueDraft({ path })
+    if (Option.isNone(content)) {
+      return Option.none<{
+        readonly content: string
+        readonly frontMatter: typeof FrontMatterSchema.Type
+        readonly issue: PrdIssue
+      }>()
+    }
+
+    let validationError: IssueDraftValidationError | undefined = undefined
+    const parsed = yield* parseIssueDraft(content.value).pipe(
+      Effect.match({
+        onFailure: (error) => {
+          validationError = error
+          return Option.none<{
+            readonly content: string
+            readonly frontMatter: typeof FrontMatterSchema.Type
+            readonly issue: PrdIssue
+          }>()
+        },
+        onSuccess: Option.some,
+      }),
+    )
+    if (Option.isSome(parsed)) {
+      return parsed
+    }
+
+    yield* Effect.logError(validationError!.message)
+    const reopen = yield* Prompt.toggle({
+      message:
+        "The issue draft is malformed. Reopen it in your editor to repair it?",
+      initial: true,
+    })
+    if (!reopen) {
+      return Option.none()
+    }
+  }
+})
+
+export const prepareInteractiveIssueDraftSession = Effect.fn(
+  "prepareInteractiveIssueDraftSession",
+)(function* () {
+  const fs = yield* FileSystem.FileSystem
+  const pathService = yield* Path.Path
+  const root = yield* resolveLalphDirectory
+  const draftPath = pathService.join(root, interactiveIssueDraftRelativePath)
+  const lockPath = `${draftPath}.lock`
+
+  yield* fs.makeDirectory(pathService.dirname(draftPath), {
+    recursive: true,
+  })
+
+  if (yield* fs.exists(lockPath)) {
+    return yield* new InteractiveIssueDraftInProgress({ draftPath })
+  }
+
+  if (yield* fs.exists(draftPath)) {
+    const recoveredPath = pathService.join(
+      pathService.dirname(draftPath),
+      `issue-draft.recovered-${new Date().toISOString().replaceAll(":", "-")}.md`,
+    )
+    yield* fs.copy(draftPath, recoveredPath)
+    yield* fs.remove(draftPath)
+    yield* Effect.log(
+      `Recovered a stale interactive issue draft to: ${recoveredPath}`,
+    )
+  }
+
+  yield* fs.writeFileString(
+    lockPath,
+    `pid=${process.pid}\ncreatedAt=${new Date().toISOString()}\n`,
+  )
+
+  yield* Effect.addFinalizer(() =>
+    fs.remove(lockPath, { force: true }).pipe(Effect.ignore),
+  )
+
+  return {
+    root,
+    draftPath,
+    deleteDraft: fs.remove(draftPath, { force: true }).pipe(Effect.ignore),
+    ensureDraftExists: fs.exists(draftPath).pipe(
+      Effect.flatMap((exists) =>
+        exists
+          ? Effect.void
+          : Effect.fail(
+              new InteractiveIssueDraftMissing({
+                draftPath,
+              }),
+            ),
+      ),
+    ),
+  } as const
+})

--- a/src/PromptGen.ts
+++ b/src/PromptGen.ts
@@ -2,6 +2,10 @@ import { Effect, Layer, ServiceMap } from "effect"
 import { PrdIssue } from "./domain/PrdIssue.ts"
 import { CurrentIssueSource } from "./CurrentIssueSource.ts"
 import type { GitFlow } from "./GitFlow.ts"
+import {
+  interactiveIssueDraftRelativePath,
+  issueTemplate,
+} from "./IssueDraft.ts"
 
 export class PromptGen extends ServiceMap.Service<PromptGen>()(
   "lalph/PromptGen",
@@ -481,6 +485,60 @@ Make sure to setup dependencies between the tasks using the \`blockedBy\` field.
 
 **Important:** You are only creating or updating a plan, not implementing any tasks yet.`
 
+      const promptIssueInterview = (options: {
+        readonly projectId: string
+        readonly issueSourceName: string
+        readonly request: string
+        readonly draftPath: string
+      }) => `You are helping draft a new issue for the active project.
+
+Project context:
+- Project id: ${options.projectId}
+- Issue source: ${options.issueSourceName}
+
+High-level request:
+<request>
+${options.request}
+</request>
+
+Your job is to run an interactive terminal interview with the user until you have
+enough information to produce a complete issue draft.
+
+Instructions:
+1. Ask clarifying questions directly in the terminal whenever requirements are missing or ambiguous.
+2. Do not stop after one question if important details are still unclear.
+3. Once you have enough detail, write the final issue draft to \`${options.draftPath}\`.
+4. The file must use this exact structure:
+
+\`\`\`md
+${issueTemplate.trimEnd()}
+Issue description goes here.
+\`\`\`
+
+5. The front matter must satisfy these requirements:
+
+\`\`\`json
+${JSON.stringify(
+  {
+    title: "string",
+    priority: "number",
+    estimate: "number | null",
+    blockedBy: ["string"],
+    autoMerge: "boolean",
+  },
+  null,
+  2,
+)}
+\`\`\`
+
+6. Keep the description in markdown below the front matter. Use an empty description if none was provided.
+7. Overwrite the draft file with the final result and then tell the user that the draft was written.
+
+Important:
+- Do not create the issue yourself.
+- Do not write anywhere except \`${interactiveIssueDraftRelativePath}\`.
+- The user will review the draft in their editor after your interview.`
+
       return {
         promptChoose,
         promptChooseClanka,
@@ -497,6 +555,7 @@ Make sure to setup dependencies between the tasks using the \`blockedBy\` field.
         planPrompt,
         promptPlanTasks,
         promptPlanTasksClanka,
+        promptIssueInterview,
         systemClanka,
       } as const
     }),

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -1,103 +1,127 @@
-import { Command } from "effect/unstable/cli"
+import { Command, Flag, Prompt } from "effect/unstable/cli"
 import { CurrentIssueSource } from "../CurrentIssueSource.ts"
-import { Effect, Exit, flow, Option, pipe, Schema } from "effect"
-import { IssueSource } from "../IssueSource.ts"
-import { PrdIssue } from "../domain/PrdIssue.ts"
-import * as Yaml from "yaml"
-import { CurrentProjectId } from "../Settings.ts"
-import { layerProjectIdPrompt } from "../Projects.ts"
+import { Effect, Option } from "effect"
+import { CurrentProjectId, Settings } from "../Settings.ts"
+import { layerProjectIdPrompt, selectProject } from "../Projects.ts"
 import { Editor } from "../Editor.ts"
+import {
+  createIssueFromDraft,
+  issueTemplate,
+  parseIssueDraft,
+  prepareInteractiveIssueDraftSession,
+  recoverIssueDraftOnFailure,
+  reviewIssueDraft,
+  reviewIssueDraftFileUntilValid,
+} from "../IssueDraft.ts"
+import { selectCliAgentPreset } from "../Presets.ts"
+import { agentIssueInterviewer } from "../Agents/issueInterviewer.ts"
+import { PromptGen } from "../PromptGen.ts"
 
-const issueTemplate = `---
-title: Issue Title
-priority: 3
-estimate: null
-blockedBy: []
-autoMerge: false
----
-
-`
-
-const FrontMatterSchema = Schema.toCodecJson(
-  Schema.Struct({
-    title: Schema.String,
-    priority: Schema.Finite,
-    estimate: Schema.NullOr(Schema.Finite),
-    blockedBy: Schema.Array(Schema.String),
-    autoMerge: Schema.Boolean,
-  }),
-)
-
-const handler = flow(
-  Command.withHandler(
-    Effect.fnUntraced(function* () {
-      const editor = yield* Editor
-
-      const content = yield* editor.editTemp({
-        suffix: ".md",
-        initialContent: issueTemplate,
-      })
-      if (Option.isNone(content)) {
-        return
-      }
-      const contentValue = content.value.trim()
-
-      yield* Effect.addFinalizer((exit) => {
-        if (Exit.isSuccess(exit)) return Effect.void
-        return pipe(
-          editor.saveTemp(contentValue, { suffix: ".md" }),
-          Effect.flatMap((file) => Effect.log(`Saved your issue to: ${file}`)),
-          Effect.ignore,
-        )
-      })
-
-      const lines = contentValue.split("\n")
-      const yamlLines: string[] = []
-      let descriptionStartIndex = 0
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i]!
-        if (line.trim() === "---") {
-          if (yamlLines.length === 0) {
-            // starting delimiter
-            continue
-          } else {
-            // ending delimiter
-            descriptionStartIndex = i + 1
-            break
-          }
-        }
-        yamlLines.push(line)
-      }
-      const yamlContent = yamlLines.join("\n")
-      const frontMatter = yield* Schema.decodeEffect(FrontMatterSchema)(
-        Yaml.parse(yamlContent),
-      )
-      const description = lines.slice(descriptionStartIndex).join("\n").trim()
-
-      if (frontMatter.title.trim() === "Issue Title") return
-
-      yield* Effect.gen(function* () {
-        const source = yield* IssueSource
-        const projectId = yield* CurrentProjectId
-        const created = yield* source.createIssue(
-          projectId,
-          new PrdIssue({
-            id: null,
-            ...frontMatter,
-            description,
-            state: "todo",
-          }),
-        )
-        console.log(`Created issue with ID: ${created.id}`)
-        console.log(`URL: ${created.url}`)
-      }).pipe(Effect.provide([layerProjectIdPrompt, CurrentIssueSource.layer]))
-    }, Effect.scoped),
+const interactive = Flag.boolean("interactive").pipe(
+  Flag.withAlias("i"),
+  Flag.withDescription(
+    "Interview with a supported CLI agent to build .lalph/issue-draft.md, then require editor review before creating the issue.",
   ),
-  Command.provide(Editor.layer),
 )
 
-export const commandIssue = Command.make("issue").pipe(
-  Command.withDescription("Create a new issue in your editor."),
+const printCreatedIssue = (created: {
+  readonly id: string
+  readonly url: string
+}) =>
+  Effect.sync(() => {
+    console.log(`Created issue with ID: ${created.id}`)
+    console.log(`URL: ${created.url}`)
+  })
+
+const runStandardIssue = Effect.fnUntraced(function* () {
+  const content = yield* reviewIssueDraft({
+    initialContent: issueTemplate,
+  })
+  if (Option.isNone(content)) {
+    return
+  }
+
+  yield* recoverIssueDraftOnFailure(content.value)
+  const projectId = yield* CurrentProjectId
+  const parsed = yield* parseIssueDraft(content.value)
+
+  if (parsed.frontMatter.title.trim() === "Issue Title") {
+    return
+  }
+
+  const created = yield* createIssueFromDraft({
+    projectId,
+    content: content.value,
+  })
+
+  yield* printCreatedIssue(created.created)
+})
+
+const runInteractiveIssue = Effect.fnUntraced(function* () {
+  const project = yield* selectProject
+  const sourceMeta = yield* CurrentIssueSource
+  const request = yield* Prompt.text({
+    message: "What issue do you want to create?",
+    validate: (input) =>
+      input.trim().length === 0
+        ? Effect.fail("The issue request cannot be empty")
+        : Effect.succeed(input),
+  })
+  const preset = yield* selectCliAgentPreset
+  const draftSession = yield* prepareInteractiveIssueDraftSession()
+
+  yield* agentIssueInterviewer({
+    cwd: draftSession.root,
+    projectId: project.id,
+    issueSourceName: sourceMeta.name,
+    request,
+    draftPath: draftSession.draftPath,
+    preset,
+  })
+
+  yield* draftSession.ensureDraftExists
+  const reviewed = yield* reviewIssueDraftFileUntilValid(draftSession.draftPath)
+  if (Option.isNone(reviewed)) {
+    yield* Effect.log(
+      `Interactive issue draft preserved at: ${draftSession.draftPath}`,
+    )
+    return
+  }
+
+  const created = yield* createIssueFromDraft({
+    projectId: project.id,
+    content: reviewed.value.content,
+  })
+
+  yield* draftSession.deleteDraft
+  yield* printCreatedIssue(created.created)
+})
+
+export const commandIssue = Command.make("issue", {
+  interactive,
+}).pipe(
+  Command.withDescription(
+    "Create a new issue either from your editor template or, with --interactive, by interviewing with a supported CLI agent and then reviewing the generated draft.",
+  ),
   Command.withAlias("i"),
-  handler,
+  Command.withHandler(
+    Effect.fnUntraced(
+      function* ({ interactive }) {
+        if (interactive) {
+          return yield* runInteractiveIssue()
+        }
+
+        return yield* runStandardIssue().pipe(
+          Effect.provide([layerProjectIdPrompt, CurrentIssueSource.layer]),
+        )
+      },
+      Effect.scoped,
+      Effect.provide([
+        Editor.layer,
+        Settings.layer,
+        CurrentIssueSource.layer,
+        PromptGen.layer,
+      ]),
+    ),
+  ),
 )

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -7,6 +7,7 @@ import { Editor } from "../Editor.ts"
 import {
   createIssueFromDraft,
   issueTemplate,
+  issueTitlePlaceholder,
   parseIssueDraft,
   prepareInteractiveIssueDraftSession,
   recoverIssueDraftOnFailure,
@@ -45,7 +46,7 @@ const runStandardIssue = Effect.fnUntraced(function* () {
   const projectId = yield* CurrentProjectId
   const parsed = yield* parseIssueDraft(content.value)
 
-  if (parsed.frontMatter.title.trim() === "Issue Title") {
+  if (parsed.frontMatter.title.trim() === issueTitlePlaceholder) {
     return
   }
 
@@ -80,7 +81,15 @@ const runInteractiveIssue = Effect.fnUntraced(function* () {
   })
 
   yield* draftSession.ensureDraftExists
-  const reviewed = yield* reviewIssueDraftFileUntilValid(draftSession.draftPath)
+  const reviewed = yield* reviewIssueDraftFileUntilValid(
+    draftSession.draftPath,
+    {
+      validate: ({ frontMatter }) =>
+        frontMatter.title.trim() === issueTitlePlaceholder
+          ? "Issue draft title is still the placeholder value. Update the title before creating the issue."
+          : undefined,
+    },
+  )
   if (Option.isNone(reviewed)) {
     yield* Effect.log(
       `Interactive issue draft preserved at: ${draftSession.draftPath}`,

--- a/src/domain/CliAgent.ts
+++ b/src/domain/CliAgent.ts
@@ -17,6 +17,11 @@ export class CliAgent<const Id extends string> extends Data.Class<{
     readonly prdFilePath: string | undefined
     readonly extraArgs: ReadonlyArray<string>
   }) => ChildProcess.Command
+  commandIssue?: (options: {
+    readonly prompt: string
+    readonly prdFilePath: string | undefined
+    readonly extraArgs: ReadonlyArray<string>
+  }) => ChildProcess.Command
   commandPlan: (options: {
     readonly prompt: string
     readonly prdFilePath: string | undefined
@@ -81,6 +86,28 @@ const opencode = new CliAgent({
         stdin: "inherit",
       },
     ),
+  commandIssue: ({ prompt, prdFilePath, extraArgs }) =>
+    ChildProcess.make(
+      "opencode",
+      [
+        "--prompt",
+        prdFilePath
+          ? `@${prdFilePath}
+
+${prompt}`
+          : prompt,
+        ...extraArgs,
+      ],
+      {
+        extendEnv: true,
+        env: {
+          OPENCODE_PERMISSION: '{"*":"allow", "question":"allow"}',
+        },
+        stdout: "inherit",
+        stderr: "inherit",
+        stdin: "inherit",
+      },
+    ),
   commandPlan: ({ prompt, prdFilePath, dangerous }) =>
     ChildProcess.make(
       "opencode",
@@ -136,6 +163,25 @@ ${prompt}`
       },
     ),
   outputTransformer: claudeOutputTransformer,
+  commandIssue: ({ prompt, prdFilePath, extraArgs }) =>
+    ChildProcess.make(
+      "claude",
+      [
+        "--dangerously-skip-permissions",
+        ...extraArgs,
+        "--",
+        prdFilePath
+          ? `@${prdFilePath}
+
+${prompt}`
+          : prompt,
+      ],
+      {
+        stdout: "inherit",
+        stderr: "inherit",
+        stdin: "inherit",
+      },
+    ),
   commandPlan: ({ prompt, prdFilePath, dangerous }) =>
     ChildProcess.make(
       "claude",
@@ -172,6 +218,24 @@ ${prompt}`
       {
         stdout: "pipe",
         stderr: "pipe",
+        stdin: "inherit",
+      },
+    ),
+  commandIssue: ({ prompt, prdFilePath, extraArgs }) =>
+    ChildProcess.make(
+      "codex",
+      [
+        "--dangerously-bypass-approvals-and-sandbox",
+        ...extraArgs,
+        prdFilePath
+          ? `@${prdFilePath}
+
+${prompt}`
+          : prompt,
+      ],
+      {
+        stdout: "inherit",
+        stderr: "inherit",
         stdin: "inherit",
       },
     ),


### PR DESCRIPTION
Closes #24

## Summary
- add shared issue draft parsing, editor review, recovery, and deterministic interactive draft lifecycle helpers
- add interactive issue interviewer support via `CliAgent.commandIssue`, supported-agent checks, and `lalph issue --interactive`
- document the new workflow in the README, specs index, and add the feature changeset